### PR TITLE
docs: fix grammar in README Grounding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ see [Fixed and Remaining Issues](#fixed-and-remaining-issues).
 
 + Hugging Face provides GGUF format model weights. You can download the GGUF format model of GLM-V from [here](https://huggingface.co/collections/ggml-org/glm-v).
 
-## Using Case
+## Use Cases
 
 ### Grounding
 
-GLM-4.5V / GLM-4.6V / GLM-4.1V equips precise grounding capabilities. Given a prompt that requests the location of a specific object, the model
-is able to reasoning step-by-step and identify the bounding boxes of the target object. The query prompt supports
+GLM-4.5V / GLM-4.6V / GLM-4.1V have precise grounding capabilities. Given a prompt that requests the location of a specific object, the model
+is able to reason step-by-step and identify the bounding boxes of the target object. The query prompt supports
 complex descriptions of the target object as well as specified output formats, for example:
 >
 > - Help me to locate <expr> in the image and give me its bounding boxes.


### PR DESCRIPTION
Three small README fixes in the Grounding section:

1. `## Using Case` → `## Use Cases` ("Use Cases" is the conventional heading; "Using Case" is an awkward translation artifact).
2. `models equips precise grounding capabilities` → `models have precise grounding capabilities`. "Equip" means "to provide"; a model "has" capabilities. Also the subject is plural (`GLM-4.5V / GLM-4.6V / GLM-4.1V`), so subject-verb agreement requires `have`.
3. `the model is able to reasoning step-by-step` → `the model is able to reason step-by-step`. "is able to" requires the bare infinitive, not the gerund. Parallel structure with the later `and identify` confirms the intended form.