### PR TITLE
Fix ensure_list splitting str/bytes into characters

### DIFF
--- a/glmv_reward/src/glmv_reward/utils/misc.py
+++ b/glmv_reward/src/glmv_reward/utils/misc.py
@@ -2,12 +2,18 @@
 
 
 from collections.abc import Sequence
-from typing import TypeVar, Union
+from typing import TypeVar, Union, cast
 
 T = TypeVar("T")
 
 
 def ensure_list(obj: Union[Sequence[T], T]) -> list[T]:
+    # `str`/`bytes` are `Sequence` subclasses, but callers hand them over as a
+    # single scalar value (a prompt, an API key, a judge URL) rather than as a
+    # sequence of characters. Wrap them like any other non-sequence value so we
+    # don't explode "sk-abc" into ["s", "k", "-", "a", "b", "c"].
+    if isinstance(obj, (str, bytes, bytearray)):
+        return [cast(T, obj)]
     if isinstance(obj, Sequence):
         return list(obj)
     return [obj]

--- a/glmv_reward/tests/utils/test_misc.py
+++ b/glmv_reward/tests/utils/test_misc.py
@@ -1,0 +1,34 @@
+from glmv_reward.utils.misc import ensure_list, ensure_text
+
+
+def test_ensure_list_wraps_single_string():
+    # A str is a Sequence, but the public APIs (get_reward, verifier llm_api_key /
+    # llm_judge_url / llm_model) accept a single string and must treat it as one
+    # element instead of splitting it into characters.
+    assert ensure_list("hello") == ["hello"]
+    assert ensure_list("") == [""]
+    assert ensure_list("https://open.bigmodel.cn/api/paas/v4/chat/completions") == [
+        "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+    ]
+
+
+def test_ensure_list_wraps_single_bytes():
+    assert ensure_list(b"hello") == [b"hello"]
+    assert ensure_list(bytearray(b"hi")) == [bytearray(b"hi")]
+
+
+def test_ensure_list_keeps_real_sequences():
+    assert ensure_list(["a", "b"]) == ["a", "b"]
+    assert ensure_list(("a", "b")) == ["a", "b"]
+    assert ensure_list([]) == []
+
+
+def test_ensure_list_wraps_non_sequence_scalars():
+    assert ensure_list(5) == [5]
+    assert ensure_list(1.5) == [1.5]
+    assert ensure_list(None) == [None]
+
+
+def test_ensure_text_passthrough_and_decode():
+    assert ensure_text("abc") == "abc"
+    assert ensure_text(b"abc") == "abc"


### PR DESCRIPTION
`ensure_list()` uses `isinstance(obj, Sequence)` to decide whether to wrap or spread its argument, but `str`/`bytes` **are** `Sequence` subclasses — so a single string is exploded into one-character elements instead of being wrapped as `["the string"]`.

This corrupts the documented `Union[Sequence[str], str]` inputs:
- `RewardSystem.get_reward` — a single-string `prompts`/`answers`/`gt_answers` is scored one character at a time.
- Every verifier's LLM-judge fallback — a scalar `llm_api_key`/`llm_judge_url`/`llm_model`. This scalar form is the one shipped in the project's own `configs/full_config.yaml`, so when the fallback fires the judge URL is requested **one character at a time** and then crashes with `ValueError: zip() argument 3 is shorter than arguments 1-2`.

Treat `str`/`bytes`/`bytearray` as scalar before the `Sequence` check. Adds tests for the previously-untested `misc` helpers.
