### PR TITLE
fix(glmv-grounding): validate prepared media URLs

### DIFF
--- a/skills/glmv-grounding/scripts/glm_grounding_cli.py
+++ b/skills/glmv-grounding/scripts/glm_grounding_cli.py
@@ -203,11 +203,18 @@ def _encode_file(file_path: str) -> tuple[str, str]:
 def load_media_bytes(source: str):
     """Get bytes for a media URL or local file path."""
     if _is_url(source):
-        ok, reason = _is_public_url(source)
+        try:
+            request_url = requests.Request("GET", source).prepare().url
+        except Exception as e:
+            return None, f"Failed to prepare image URL: {e}"
+        if not request_url:
+            return None, "Failed to prepare image URL"
+
+        ok, reason = _is_public_url(request_url)
         if not ok:
             return None, f"Rejected URL for security reasons: {reason}"
         try:
-            resp = requests.get(source, timeout=10)
+            resp = requests.get(request_url, timeout=10)
             resp.raise_for_status()
             return resp.content, ""
         except Exception as e:

--- a/skills/glmv-grounding/tests/test_glm_grounding_cli.py
+++ b/skills/glmv-grounding/tests/test_glm_grounding_cli.py
@@ -1,0 +1,68 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def _load_cli(monkeypatch):
+    scripts_dir = Path(__file__).parents[1] / "scripts"
+    for name, attributes in {
+        "utils_boxes": ("parse_coordinates_from_response", "visualize_boxes"),
+        "utils_detection": ("parse_detection_from_response",),
+        "utils_video": ("parse_mot_from_response", "visualize_mot"),
+    }.items():
+        module = ModuleType(name)
+        for attribute in attributes:
+            setattr(module, attribute, Mock())
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    spec = importlib.util.spec_from_file_location(
+        "glm_grounding_cli", scripts_dir / "glm_grounding_cli.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_media_bytes_rejects_requests_parser_bypass(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    get = Mock()
+    monkeypatch.setattr(cli.requests, "get", get)
+
+    content, error = cli.load_media_bytes(r"http://127.0.0.1:6666\@1.1.1.1")
+
+    assert content is None
+    assert error.startswith("Rejected URL for security reasons:")
+    get.assert_not_called()
+
+
+def test_load_media_bytes_validates_and_fetches_the_same_prepared_url(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    response = Mock(content=b"image-bytes")
+    get = Mock(return_value=response)
+    monkeypatch.setattr(cli.requests, "get", get)
+    monkeypatch.setattr(
+        cli.socket,
+        "getaddrinfo",
+        Mock(
+            return_value=[
+                (
+                    cli.socket.AF_INET,
+                    cli.socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("93.184.216.34", 0),
+                )
+            ]
+        ),
+    )
+
+    content, error = cli.load_media_bytes("https://example.com/image name.png")
+
+    assert content == b"image-bytes"
+    assert error == ""
+    get.assert_called_once_with("https://example.com/image%20name.png", timeout=10)
+    response.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
## Summary

- canonicalize remote media URLs with `requests` before checking the destination host
- validate and fetch the same prepared URL so parser differences cannot change the target
- add regression coverage for the reported bypass and for a normal canonicalized URL

Closes #264

## Validation

- `uv run --isolated --python 3.12 --with pytest --with requests pytest skills/glmv-grounding/tests/test_glm_grounding_cli.py -q` (`2 passed`)
- `ruff check --select I,F401,F821` on the changed Python files
- `black --check` on the changed Python files
- `py_compile` on the changed Python files