### PR TITLE
fix(verifiers): name the judge() image parameter image_file everywhere

### DIFF
--- a/glmv_reward/src/glmv_reward/verifiers/counting_verifier.py
+++ b/glmv_reward/src/glmv_reward/verifiers/counting_verifier.py
@@ -74,7 +74,7 @@ class CountingVerifier(Verifier):
         extracted_answer: Any,
         ground_truth: Any,
         question: Optional[str] = None,
-        image_path: Optional[str] = None,
+        image_file: Optional[str] = None,
         debug: bool = False,
     ) -> float:
         if debug:
@@ -102,7 +102,7 @@ class CountingVerifier(Verifier):
             and self.llm_judge_url is not None
             and self.llm_judge_prompt_template is not None
         ):
-            return self._llm_judge_fallback(extracted_answer, ground_truth, question, image_path)
+            return self._llm_judge_fallback(extracted_answer, ground_truth, question, image_file)
 
         return self.min_reward
 

--- a/glmv_reward/src/glmv_reward/verifiers/mmsi_verifier.py
+++ b/glmv_reward/src/glmv_reward/verifiers/mmsi_verifier.py
@@ -81,7 +81,7 @@ class MmsiVerifier(Verifier):
         extracted_answer: Any,
         ground_truth: Any,
         question: Optional[str] = None,
-        image_paths: Optional[str] = None,
+        image_file: Optional[str] = None,
     ) -> float:
         if not isinstance(extracted_answer, str) or not isinstance(ground_truth, str):
             _logger.warning(
@@ -127,7 +127,7 @@ class MmsiVerifier(Verifier):
             # logging configuration is in place, replace them with calls to the standard
             # `logging` module (e.g. logger.warning / logger.info / logger.debug).
             if self.enable_llm_judge_fallback:
-                return self._llm_judge_fallback(extracted_answer, ground_truth, question, image_paths)
+                return self._llm_judge_fallback(extracted_answer, ground_truth, question, image_file)
             return self.min_reward  # If sympy must pass or no fallback (or fallback disabled)
         else:
             # If they are relations (e.g. x > 0)

--- a/glmv_reward/src/glmv_reward/verifiers/verifier_from_file.py
+++ b/glmv_reward/src/glmv_reward/verifiers/verifier_from_file.py
@@ -54,8 +54,8 @@ class FileBasedVerifier(Verifier):
         extracted_answer: Any,
         ground_truth: Any,  # This will also be an "extracted" ground truth
         question: Optional[str] = None,
-        image_path: Optional[List[str]] = None,
+        image_file: Optional[List[str]] = None,
     ) -> float:
         if not self.load_once:
             self.load_judge_function()
-        return self.judge_func(extracted_answer, ground_truth, question, image_path)
+        return self.judge_func(extracted_answer, ground_truth, question, image_file)

--- a/glmv_reward/tests/test_judge_signature_contract.py
+++ b/glmv_reward/tests/test_judge_signature_contract.py
@@ -1,0 +1,39 @@
+"""Every Verifier.judge must accept the image_file keyword that RewardSystem passes.
+
+RewardSystem._process_single_item calls
+
+    verifier.judge(extracted_ans, extracted_gt, question=prompt, image_file=image_file)
+
+inside `except Exception: reward = min_reward`, so a verifier whose judge() spells that
+parameter differently does not fail loudly. Every sample it handles scores the minimum
+with only a warning in the log.
+"""
+
+import importlib
+import inspect
+import pkgutil
+
+import glmv_reward.verifiers as verifiers_pkg
+from glmv_reward.verifiers._base_verifier import Verifier
+
+
+def _concrete_verifier_classes():
+    found = {}
+    for mod in pkgutil.iter_modules(verifiers_pkg.__path__):
+        module = importlib.import_module(f"glmv_reward.verifiers.{mod.name}")
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, Verifier) and obj is not Verifier and not inspect.isabstract(obj):
+                found[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return dict(sorted(found.items()))
+
+
+def test_every_judge_accepts_the_image_file_keyword():
+    offenders = []
+    for name, cls in _concrete_verifier_classes().items():
+        params = inspect.signature(cls.judge).parameters
+        accepts_var_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+        if "image_file" not in params and not accepts_var_kwargs:
+            offenders.append(f"  {name}: {list(params)}")
+    assert not offenders, "judge() must accept the image_file keyword RewardSystem passes; these do not:\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
`RewardSystem._process_single_item` calls every verifier the same way (`reward_system.py:116`):

```python
reward = verifier.judge(extracted_ans, extracted_gt, question=prompt, image_file=image_file)
```

`image_file` is passed as a keyword, and the abstract `Verifier.judge` declares it under that name (`_base_verifier.py:36`). Three verifiers spell it differently and accept no `**kwargs`:

| Verifier | parameter on main |
|---|---|
| `CountingVerifier` (`counting_verifier.py:77`) | `image_path` |
| `MmsiVerifier` (`mmsi_verifier.py:84`) | `image_paths` |
| `FileBasedVerifier` (`verifier_from_file.py:57`) | `image_path` |

So the call raises `TypeError: judge() got an unexpected keyword argument 'image_file'`.

## Why it is silent

That call is wrapped in `except Exception as e: _logger.warning(...); reward = min_reward`. Nothing propagates. Every counting and mmsi sample scores the minimum with one warning line, which reads as the model answering badly rather than the verifier never running at all.

## The fix

Rename the parameter in those three. The other nine verifiers (general, math, chart, ocr, vqa, physics, chemistry, biology, geography) already use `image_file`, and `_llm_judge_fallback` in the affected files already did too, so this only touches the public `judge` signature and the one call that forwards it.

## Verification

`tests/test_judge_signature_contract.py` walks every concrete `Verifier` subclass and asserts its `judge` accepts `image_file` (or `**kwargs`). It fails on main:

```
AssertionError: judge() must accept the image_file keyword RewardSystem passes; these do not:
  glmv_reward.verifiers.counting_verifier.CountingVerifier: ['self', 'extracted_answer', 'ground_truth', 'question', 'image_path', 'debug']
  glmv_reward.verifiers.mmsi_verifier.MmsiVerifier: ['self', 'extracted_answer', 'ground_truth', 'question', 'image_paths']
  glmv_reward.verifiers.verifier_from_file.FileBasedVerifier: ['self', 'extracted_answer', 'ground_truth', 'question', 'image_path']
```

and passes with the rename. It is written as a contract check rather than three separate cases so a future verifier cannot reintroduce the same mismatch.

Full suite, same machine:

```
pristine main   87 failed, 101 passed
with this PR    87 failed, 102 passed
```

Same 87 pre-existing failures either side, the +1 is this test. The pre-existing failures look environmental (the LLM-judge paths need credentials I do not have), and I have not touched them.

`ruff check` on the three changed sources reports the same 2 pre-existing `F401` unused-`abc`-import findings in `verifier_from_file.py` before and after; I left them alone as unrelated. The new test trips `INP001` and `S101` exactly as the existing `tests/counting/test_counting.py` does, so it matches how tests in this repo are already written.
